### PR TITLE
Prevent Screen flicker by displaying new moist values only

### DIFF
--- a/plant_humidity_sensor/src/src.ino
+++ b/plant_humidity_sensor/src/src.ino
@@ -15,6 +15,7 @@ int threeThirdMOisture = 934.75; //Somewhat wet
 int maxMoisture = 1023; //Completely Dry
 //Was 50
 int moistureThreshold = 848;
+int lastMoisture = -1;
 
 void setup() {
   Serial.begin(9600);
@@ -29,13 +30,15 @@ void loop() {
   int rawMoistValue = analogRead(moistPin);
   int moistValue = rawMoistValue;
   
-  if(moistValue < moistureThreshold){
-   //The moisture level is reaching wettest level (Could be problematic as too much water is bad)
-    displayGoodHealth(moistValue);
+  if(lastMoisture != moistValue){
+    //The moisture level is reaching wettest level (Could be problematic as too much water is bad)
+    if(moistValue < moistureThreshold)
+      displayGoodHealth(moistValue);
+    else
+      displayBadHealth(moistValue);
   }
-  else
-    displayBadHealth(moistValue);
-  
+
+  lastMoisture = moistValue;
   delay(1000);
 }
 
@@ -45,11 +48,11 @@ void displayGoodHealth(int moistureValue){
   //The LCD display
   carrier.display.fillScreen(ST77XX_GREEN);
   carrier.display.setTextColor(ST77XX_WHITE);
-Serial.print("I'm in good health! Moisture: ");
+  Serial.print("I'm in good health! Moisture: ");
   Serial.println(moistureValue);
   carrier.display.setCursor(30, 50);
-  carrier.display.print("Moisture Level: ");
   carrier.display.setTextSize(4);
+  carrier.display.print("Moisture Level: ");
   carrier.display.setCursor(40, 120);
   carrier.display.print(moistureValue);
   
@@ -64,8 +67,8 @@ void displayBadHealth(int moistureValue){
   carrier.display.setTextColor(ST77XX_WHITE);
 
   carrier.display.setCursor(30, 50);
-  carrier.display.print("Moisture Level: ");
   carrier.display.setTextSize(4);
+  carrier.display.print("Moisture Level: ");
   carrier.display.setCursor(40, 120);
   carrier.display.print(moistureValue);
 }


### PR DESCRIPTION
# What have I changed?
I added a new variable, called lastMoisture, which tracks the last scanned moist value from the sensor. The display functions are only called when the past and new moist values are different.
# Why have I changed it?
As of now, the screen flickers, since it redraws everything every second or so. With this change, the screen will stay static, and only redraw when the moist value changes, making it less visually straining.